### PR TITLE
DTCE-2751: Extract assets into separate file

### DIFF
--- a/resources/views/assets/assets.blade.php
+++ b/resources/views/assets/assets.blade.php
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="{{ mix('css/customer-experience.css', "vendor/customer-experience") }}">
+<script src="{{ mix('js/customer-experience.js', "vendor/customer-experience") }}"></script>

--- a/resources/views/components/widget.blade.php
+++ b/resources/views/components/widget.blade.php
@@ -47,17 +47,6 @@
             && $currentTime->lessThan($callClosingTime);
     @endphp
 
-    <x-lego::app-asset
-        asset="js/customer-experience.js"
-        :type="Helix\Lego\Enums\AppAsset::SCRIPT"
-        vendor="customer-experience"
-    />
-    <x-lego::app-asset
-        asset="css/customer-experience.css"
-        :type="Helix\Lego\Enums\AppAsset::STYLESHEET"
-        vendor="customer-experience"
-    />
-
     <div
         data-area="cx"
         class="{{ $this->css('cxBackground') }}"


### PR DESCRIPTION
This is breaking when caching is enabled on a site. So that's we need need to extract the assets out of the file and into its own separate Blade file that we can then include in the `playset` repository where needed.